### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/site-prism/testingrecord/security/code-scanning/1](https://github.com/site-prism/testingrecord/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` to enforce least privilege for `GITHUB_TOKEN`.

Best fix here: define workflow-level permissions right after the `on:` block (or after `name`/`on` section) so all jobs inherit it unless overridden. For this CI workflow, `contents: read` is the minimal required starting point and is sufficient for `actions/checkout` and read-only CI tasks.

Changes needed:
- File: `.github/workflows/ci.yml`
- Insert:
  - `permissions:`
  - `  contents: read`
- No imports, methods, or additional definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
